### PR TITLE
Fix typo in estimators/linear.ipynb tutorial code

### DIFF
--- a/site/en/tutorials/estimators/linear.ipynb
+++ b/site/en/tutorials/estimators/linear.ipynb
@@ -1162,7 +1162,7 @@
         "\n",
         "clear_output()\n",
         "\n",
-        "for key,value in sorted(result.items()):\n",
+        "for key,value in sorted(results.items()):\n",
         "  print('%s: %0.2f' % (key, value))"
       ],
       "execution_count": 0,
@@ -1175,7 +1175,7 @@
       },
       "cell_type": "markdown",
       "source": [
-        "The first line of the output should display something like: `accuracy: 0.83`, which means the accuracy is 83%. You can try using more features and transformations to see if you can do better!\n",
+        "The first line of the output should display something like: `accuracy: 0.84`, which means the accuracy is 84%. You can try using more features and transformations to see if you can do better!\n",
         "\n",
         "After the model is evaluated, we can use it to predict whether an individual has an annual income of over 50,000 dollars given an individual's information input.\n",
         "\n",


### PR DESCRIPTION
Previous code printed evaluation result of model built couple cells before the one evaluated in this cell (note different variable names: `results` and `result` without `s` at the end; `results` is the one that was meant to be printed).
This change fixes that and updates comment that comes after to reflect actual (rounded) accuracy of this model